### PR TITLE
Fixes for type check when handling chained association navigation

### DIFF
--- a/src/main/java/de/monticore/expressions/setexpressions/types3/OCLSetExpressionsCTTIVisitor.java
+++ b/src/main/java/de/monticore/expressions/setexpressions/types3/OCLSetExpressionsCTTIVisitor.java
@@ -4,7 +4,7 @@ import de.monticore.ocl.setexpressions.types3.SetExpressionsCTTIVisitor;
 import de.monticore.ocl.types3.OCLCollectionSymTypeRelations;
 import de.monticore.types.check.SymTypeExpression;
 
-public class OCLSetExpressionsTypeVisitor extends SetExpressionsCTTIVisitor {
+public class OCLSetExpressionsCTTIVisitor extends SetExpressionsCTTIVisitor {
 
   @Override
   protected boolean isSetOrListCollection(SymTypeExpression type) {

--- a/src/main/java/de/monticore/expressions/setexpressions/types3/OCLSetExpressionsTypeVisitor.java
+++ b/src/main/java/de/monticore/expressions/setexpressions/types3/OCLSetExpressionsTypeVisitor.java
@@ -1,0 +1,16 @@
+package de.monticore.expressions.setexpressions.types3;
+
+import de.monticore.ocl.setexpressions.types3.SetExpressionsCTTIVisitor;
+import de.monticore.ocl.types3.OCLCollectionSymTypeRelations;
+import de.monticore.types.check.SymTypeExpression;
+
+public class OCLSetExpressionsTypeVisitor extends SetExpressionsCTTIVisitor {
+
+  @Override
+  protected boolean isSetOrListCollection(SymTypeExpression type) {
+    // Adds support for 'Collection' as a collection type.
+    // This is required when association roles are chained.
+    // see OCLWithinTypeBasicSymbolsResolver
+    return OCLCollectionSymTypeRelations.isOCLCollection(type);
+  }
+}

--- a/src/main/java/de/monticore/ocl/ocl/types3/OCLTypeCheck3.java
+++ b/src/main/java/de/monticore/ocl/ocl/types3/OCLTypeCheck3.java
@@ -4,11 +4,11 @@ import de.monticore.expressions.bitexpressions.types3.BitExpressionsTypeVisitor;
 import de.monticore.expressions.commonexpressions.types3.OCLCommonExpressionsCTTIVisitor;
 import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsLValueRelations;
 import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisCTTIVisitor;
-import de.monticore.ocl.oclexpressions.OCLOCLExpressionsTypeVisitor;
-import de.monticore.expressions.setexpressions.types3.OCLSetExpressionsTypeVisitor;
+import de.monticore.expressions.setexpressions.types3.OCLSetExpressionsCTTIVisitor;
 import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
 import de.monticore.ocl.ocl.OCLMill;
 import de.monticore.ocl.ocl._visitor.OCLTraverser;
+import de.monticore.ocl.oclexpressions.OCLOCLExpressionsTypeVisitor;
 import de.monticore.ocl.optionaloperators.types3.OptionalOperatorsTypeVisitor;
 import de.monticore.ocl.types3.OCLCollectionSymTypeRelations;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
@@ -93,7 +93,7 @@ public class OCLTypeCheck3 extends MapBasedTypeCheck3 {
     visOptionalOperators.setType4Ast(type4Ast);
     traverser.add4OptionalOperators(visOptionalOperators);
 
-    OCLSetExpressionsTypeVisitor visSetExpressions = new OCLSetExpressionsTypeVisitor();
+    OCLSetExpressionsCTTIVisitor visSetExpressions = new OCLSetExpressionsCTTIVisitor();
     visSetExpressions.setType4Ast(type4Ast);
     visSetExpressions.setContext4Ast(ctx4Ast);
     traverser.add4SetExpressions(visSetExpressions);

--- a/src/main/java/de/monticore/ocl/ocl/types3/OCLTypeCheck3.java
+++ b/src/main/java/de/monticore/ocl/ocl/types3/OCLTypeCheck3.java
@@ -4,12 +4,12 @@ import de.monticore.expressions.bitexpressions.types3.BitExpressionsTypeVisitor;
 import de.monticore.expressions.commonexpressions.types3.OCLCommonExpressionsCTTIVisitor;
 import de.monticore.expressions.commonexpressions.types3.util.CommonExpressionsLValueRelations;
 import de.monticore.expressions.expressionsbasis.types3.ExpressionBasisCTTIVisitor;
+import de.monticore.ocl.oclexpressions.OCLOCLExpressionsTypeVisitor;
+import de.monticore.expressions.setexpressions.types3.OCLSetExpressionsTypeVisitor;
 import de.monticore.literals.mccommonliterals.types3.MCCommonLiteralsTypeVisitor;
 import de.monticore.ocl.ocl.OCLMill;
 import de.monticore.ocl.ocl._visitor.OCLTraverser;
-import de.monticore.ocl.oclexpressions.types3.OCLExpressionsTypeVisitor;
 import de.monticore.ocl.optionaloperators.types3.OptionalOperatorsTypeVisitor;
-import de.monticore.ocl.setexpressions.types3.SetExpressionsCTTIVisitor;
 import de.monticore.ocl.types3.OCLCollectionSymTypeRelations;
 import de.monticore.ocl.types3.OCLSymTypeRelations;
 import de.monticore.ocl.types3.util.OCLWithinScopeBasicSymbolsResolver;
@@ -85,7 +85,7 @@ public class OCLTypeCheck3 extends MapBasedTypeCheck3 {
     visMCCommonLiterals.setType4Ast(type4Ast);
     traverser.add4MCCommonLiterals(visMCCommonLiterals);
 
-    OCLExpressionsTypeVisitor visOCLExpressions = new OCLExpressionsTypeVisitor();
+    OCLOCLExpressionsTypeVisitor visOCLExpressions = new OCLOCLExpressionsTypeVisitor();
     visOCLExpressions.setType4Ast(type4Ast);
     traverser.add4OCLExpressions(visOCLExpressions);
 
@@ -93,7 +93,7 @@ public class OCLTypeCheck3 extends MapBasedTypeCheck3 {
     visOptionalOperators.setType4Ast(type4Ast);
     traverser.add4OptionalOperators(visOptionalOperators);
 
-    SetExpressionsCTTIVisitor visSetExpressions = new SetExpressionsCTTIVisitor();
+    OCLSetExpressionsTypeVisitor visSetExpressions = new OCLSetExpressionsTypeVisitor();
     visSetExpressions.setType4Ast(type4Ast);
     visSetExpressions.setContext4Ast(ctx4Ast);
     traverser.add4SetExpressions(visSetExpressions);

--- a/src/main/java/de/monticore/ocl/oclexpressions/OCLOCLExpressionsTypeVisitor.java
+++ b/src/main/java/de/monticore/ocl/oclexpressions/OCLOCLExpressionsTypeVisitor.java
@@ -1,0 +1,16 @@
+package de.monticore.ocl.oclexpressions;
+
+import de.monticore.ocl.oclexpressions.types3.OCLExpressionsTypeVisitor;
+import de.monticore.ocl.types3.OCLCollectionSymTypeRelations;
+import de.monticore.types.check.SymTypeExpression;
+
+public class OCLOCLExpressionsTypeVisitor extends OCLExpressionsTypeVisitor {
+
+  @Override
+  protected boolean isSetOrList(SymTypeExpression type) {
+    // Adds support for 'Collection' as a collection type.
+    // This is required when association roles are chained.
+    // see OCLWithinTypeBasicSymbolsResolver
+    return OCLCollectionSymTypeRelations.isOCLCollection(type);
+  }
+}

--- a/src/main/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolver.java
+++ b/src/main/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolver.java
@@ -58,8 +58,7 @@ public class OCLWithinTypeBasicSymbolsResolver extends OOWithinTypeBasicSymbolsR
         unFlattenedSymType.setArgument(0, elementResolvedSymType.get());
         // need to flatten, as this is following an association
         resolvedSymType = Optional.of(OCLCollectionSymTypeRelations.flatten(unFlattenedSymType));
-        // add the original source info to the flattened symType so that other code can check what
-        // VariableSymbol was references with the given name
+        // add the original source info to the flattened symType
         resolvedSymType.ifPresent(
                 s -> s._internal_setSourceInfo(elementResolvedSymType.get()
                         .getSourceInfo())

--- a/src/main/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolver.java
+++ b/src/main/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolver.java
@@ -58,6 +58,12 @@ public class OCLWithinTypeBasicSymbolsResolver extends OOWithinTypeBasicSymbolsR
         unFlattenedSymType.setArgument(0, elementResolvedSymType.get());
         // need to flatten, as this is following an association
         resolvedSymType = Optional.of(OCLCollectionSymTypeRelations.flatten(unFlattenedSymType));
+        // add the original source info to the flattened symType so that other code can check what
+        // VariableSymbol was references with the given name
+        resolvedSymType.ifPresent(
+                s -> s._internal_setSourceInfo(elementResolvedSymType.get()
+                        .getSourceInfo())
+        );
       }
     }
     return resolvedSymType;

--- a/src/test/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolverTest.java
+++ b/src/test/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolverTest.java
@@ -48,6 +48,7 @@ public class OCLWithinTypeBasicSymbolsResolverTest extends AbstractTest {
             "message",
             "AuctionCD.Person.message"
     ).traverseAndCheck(ast);
+    assertNoFindings();
   }
 
   /**

--- a/src/test/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolverTest.java
+++ b/src/test/java/de/monticore/ocl/types3/util/OCLWithinTypeBasicSymbolsResolverTest.java
@@ -1,0 +1,100 @@
+package de.monticore.ocl.types3.util;
+
+import de.monticore.expressions.commonexpressions._ast.ASTFieldAccessExpression;
+import de.monticore.expressions.commonexpressions._visitor.CommonExpressionsVisitor2;
+import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
+import de.monticore.expressions.expressionsbasis._ast.ASTNameExpression;
+import de.monticore.expressions.expressionsbasis._visitor.ExpressionsBasisVisitor2;
+import de.monticore.ocl.ocl.AbstractTest;
+import de.monticore.ocl.ocl.OCLMill;
+import de.monticore.ocl.ocl._ast.ASTOCLCompilationUnit;
+import de.monticore.ocl.ocl._visitor.OCLTraverser;
+import de.monticore.ocl.util.SymbolTableUtil;
+import de.monticore.symboltable.ISymbol;
+import de.monticore.types.check.SymTypeExpression;
+import de.monticore.types3.TypeCheck3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OCLWithinTypeBasicSymbolsResolverTest extends AbstractTest {
+
+  @BeforeEach
+  public void setUp() {
+    super.initLogger();
+    super.initMills();
+  }
+
+  @Test
+  void flattenedSymTypeHasSourceInfoOfOriginalVariable() {
+    final Optional<ASTOCLCompilationUnit> optAST = parse(RELATIVE_MODEL_PATH
+            + "/testinput/parsable/symtab/coco/not_javagen/chainedAssocs.ocl", false);
+    assertTrue(optAST.isPresent());
+    final ASTOCLCompilationUnit ast = optAST.get();
+
+    SymbolTableUtil.prepareMill();
+    SymbolTableUtil.addCd4cSymbols();
+    SymbolTableUtil.loadSymbolFile("src/test/resources/testinput/CDs/AuctionCD.sym");
+    SymbolTableUtil.loadSymbolFile("src/test/resources/testinput/CDs/DefaultTypes.sym");
+
+    SymbolTableUtil.runSymTabGenitor(ast);
+    SymbolTableUtil.runSymTabCompleter(ast);
+
+    new AssertSourceSymbolPresentVisitor(
+            "message",
+            "AuctionCD.Person.message"
+    ).traverseAndCheck(ast);
+  }
+
+  /**
+   * Makes sure that when type checking a NameExpression or FieldAccessExpression referencing the
+   * given name, a source symbol is present and the full name of the symbol matches the
+   * expectedFullSymbolName.
+   */
+  private static class AssertSourceSymbolPresentVisitor
+          implements ExpressionsBasisVisitor2, CommonExpressionsVisitor2 {
+
+    private String variableName;
+    private String expectedFullSymbolName;
+    private boolean foundMatch = false;
+
+    public AssertSourceSymbolPresentVisitor(String variableName, String expectedFullSymbolName) {
+      this.variableName = variableName;
+      this.expectedFullSymbolName = expectedFullSymbolName;
+    }
+
+    public void traverseAndCheck(ASTOCLCompilationUnit ast) {
+      OCLTraverser traverser = OCLMill.traverser();
+      traverser.add4ExpressionsBasis(this);
+      traverser.add4CommonExpressions(this);
+      ast.accept(traverser);
+      assertTrue(foundMatch, "Found no match for variable: " + variableName);
+    }
+
+    @Override
+    public void visit(ASTNameExpression expr) {
+      if (expr.getName().equals(variableName)) {
+        assertSourceSymbolPresent(expr);
+      }
+    }
+
+    @Override
+    public void visit(ASTFieldAccessExpression expr) {
+      if (expr.getName().equals(variableName)) {
+        assertSourceSymbolPresent(expr);
+      }
+    }
+
+    protected void assertSourceSymbolPresent(ASTExpression expression) {
+      SymTypeExpression symType = TypeCheck3.typeOf(expression);
+      Optional<ISymbol> srcSymbol = symType.getSourceInfo().getSourceSymbol();
+      assertTrue(srcSymbol.isPresent());
+      assertEquals(expectedFullSymbolName, srcSymbol.get().getFullName());
+      foundMatch = true;
+    }
+  }
+}

--- a/src/test/resources/testinput/parsable/symtab/coco/not_javagen/chainedAssocs.ocl
+++ b/src/test/resources/testinput/parsable/symtab/coco/not_javagen/chainedAssocs.ocl
@@ -1,0 +1,5 @@
+ocl collectionInIterateExpr {
+
+  context int AllData.getTotalMessages()
+    post: result == this.person.message.size();
+}

--- a/src/test/resources/testinput/parsable/symtab/coco/not_javagen/collectionInSetExpr.ocl
+++ b/src/test/resources/testinput/parsable/symtab/coco/not_javagen/collectionInSetExpr.ocl
@@ -1,0 +1,15 @@
+ocl collectionInIterateExpr {
+
+  context int Company.getTotalRemainingWorkload()
+    post:
+      let
+       Collection<int> someCollection = {1, 2, 3};
+       // we want to accept type 'Collection' in generator declaration
+       Collection<int> workloads = { x * 2 | int x in someCollection, x > 1 };
+       // we want to accept type 'Collection' in 'in expression' of IterateExpression
+       int totalWorkload = iterate { w in workloads;
+                                         int accumulated = 0 :
+                                         accumulated = accumulated + w }
+      in
+        result == totalWorkload;
+}


### PR DESCRIPTION
### What?
- Accept `Collection` next to `Set` and `List` when testing for collection types in OCLExpressionsTypeVisitor and SetExpressionsTypeVisitor
  - solved by subclassing and using `OCLCollectionSymTypeRelations.isOCLCollection`
- Add original source symbol after flattening collection type of chained associations in `OCLWithinTypeBasicSymbolsResolver`

## Why?
- if we chain association roles, the flattened result is no longer strictly a `Set` or `List`, which is why the type `Collection` is used. However, `Collection` was not accepted as valid argument, e.g., in the generator declaration of a set comprehension expression.
- we need the source symbol of an association role/field for reference artifact adaptation