### PR TITLE
4835 improve error handling with guava

### DIFF
--- a/ref-ocl-adaptation/src/main/java/de/monticore/refadapt/ReferenceArtifactAdapter.java
+++ b/ref-ocl-adaptation/src/main/java/de/monticore/refadapt/ReferenceArtifactAdapter.java
@@ -1,5 +1,6 @@
 package de.monticore.refadapt;
 
+import com.google.common.base.Preconditions;
 import de.monticore.ast.ASTNode;
 import de.monticore.visitor.ITraverser;
 import de.se_rwth.commons.logging.Log;
@@ -52,10 +53,10 @@ public abstract class ReferenceArtifactAdapter<C extends IAdaptationContext> {
           AdaptationContextHolder contextHolder,
           Variants4Ast variants4Ast
   ) {
-    this.bindingVariantsTraverser = Log.errorIfNull(bindingVariantsTraverser);
-    this.adaptationTraverser = Log.errorIfNull(adaptationTraverser);
-    this.contextHolder = Log.errorIfNull(contextHolder);
-    this.variants4Ast = Log.errorIfNull(variants4Ast);
+    this.bindingVariantsTraverser = Preconditions.checkNotNull(bindingVariantsTraverser);
+    this.adaptationTraverser = Preconditions.checkNotNull(adaptationTraverser);
+    this.contextHolder = Preconditions.checkNotNull(contextHolder);
+    this.variants4Ast = Preconditions.checkNotNull(variants4Ast);
   }
 
   public ITraverser getBindingVariantsTraverser() {

--- a/src/main/java/de/monticore/ocl/codegen/visitors/CommonExpressionsPrinter.java
+++ b/src/main/java/de/monticore/ocl/codegen/visitors/CommonExpressionsPrinter.java
@@ -174,7 +174,7 @@ public class CommonExpressionsPrinter extends AbstractPrinter
 
   @Override
   public void handle(ASTArrayAccessExpression node) {
-    Log.errorIfNull(node);
+    Preconditions.checkNotNull(node);
     SymTypeExpression exprType = TypeCheck3.typeOf(node.getExpression());
     if (exprType.isObscureType()) {
       // error should be logged already

--- a/src/main/java/de/monticore/ocl/codegen/visitors/UglyExpressionsPrinter.java
+++ b/src/main/java/de/monticore/ocl/codegen/visitors/UglyExpressionsPrinter.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.ocl.codegen.visitors;
 
+import com.google.common.base.Preconditions;
 import de.monticore.expressions.expressionsbasis._ast.ASTExpression;
 import de.monticore.expressions.uglyexpressions._ast.ASTArrayCreator;
 import de.monticore.expressions.uglyexpressions._ast.ASTArrayDimensionByExpression;
@@ -28,10 +29,10 @@ public class UglyExpressionsPrinter extends AbstractPrinter
 
   public UglyExpressionsPrinter(
       IndentPrinter printer, VariableNaming naming, IDerive deriver, ISynthesize synthesizer) {
-    this.printer = Log.errorIfNull(printer);
-    this.naming = Log.errorIfNull(naming);
-    this.deriver = Log.errorIfNull(deriver);
-    this.syntheziser = Log.errorIfNull(synthesizer);
+    this.printer = Preconditions.checkNotNull(printer);
+    this.naming = Preconditions.checkNotNull(naming);
+    this.deriver = Preconditions.checkNotNull(deriver);
+    this.syntheziser = Preconditions.checkNotNull(synthesizer);
   }
 
   @Override
@@ -41,7 +42,7 @@ public class UglyExpressionsPrinter extends AbstractPrinter
 
   @Override
   public void setTraverser(UglyExpressionsTraverser traverser) {
-    Log.errorIfNull(traverser);
+    Preconditions.checkNotNull(traverser);
     this.traverser = traverser;
   }
 

--- a/src/main/java/de/monticore/ocl/ocl/_symboltable/OCLScopesGenitor.java
+++ b/src/main/java/de/monticore/ocl/ocl/_symboltable/OCLScopesGenitor.java
@@ -3,6 +3,7 @@ package de.monticore.ocl.ocl._symboltable;
 
 import static de.monticore.ocl.ocl._symboltable.OCLSymbolTableHelper.getImportStatements;
 
+import com.google.common.base.Preconditions;
 import de.monticore.ocl.ocl.OCLMill;
 import de.monticore.ocl.ocl._ast.ASTOCLCompilationUnit;
 import de.monticore.ocl.ocl._ast.ASTOCLInvariant;
@@ -19,7 +20,7 @@ public class OCLScopesGenitor extends OCLScopesGenitorTOP {
 
   @Override
   public IOCLArtifactScope createFromAST(ASTOCLCompilationUnit node) {
-    Log.errorIfNull(
+    Preconditions.checkNotNull(
         node,
         "0xAE884 Error by creating of the OCLScopesGenitor symbol table: top ast node is null");
     IOCLArtifactScope artifactScope = OCLMill.artifactScope();

--- a/src/main/java/de/monticore/ocl/types3/OCLCollectionSymTypeRelations.java
+++ b/src/main/java/de/monticore/ocl/types3/OCLCollectionSymTypeRelations.java
@@ -1,6 +1,7 @@
 // (c) https://github.com/MontiCore/monticore
 package de.monticore.ocl.types3;
 
+import com.google.common.base.Preconditions;
 import de.monticore.symbols.basicsymbols.BasicSymbolsMill;
 import de.monticore.symbols.basicsymbols._symboltable.IBasicSymbolsGlobalScope;
 import de.monticore.symbols.basicsymbols._symboltable.TypeSymbol;
@@ -105,7 +106,7 @@ public class OCLCollectionSymTypeRelations extends MCCollectionSymTypeRelations 
   }
 
   protected static void setDelegate(OCLCollectionSymTypeRelations newDelegate) {
-    OCLCollectionSymTypeRelations.delegate = Log.errorIfNull(newDelegate);
+    OCLCollectionSymTypeRelations.delegate = Preconditions.checkNotNull(newDelegate);
     MCCollectionSymTypeRelations.setDelegate(newDelegate);
   }
 


### PR DESCRIPTION
Completed subtasks:
 -  Log::errorIfNull should be deprecated and replaced
 -  Objects::requireNonNull should be replaced as well (technically not part of the Logging issue, but related)

There are still open subtasks in in issue #4835